### PR TITLE
Fixed a bug in PredefinedKeyPositionIterator

### DIFF
--- a/src/Iterators/PredefinedKeyPositionIterator.php
+++ b/src/Iterators/PredefinedKeyPositionIterator.php
@@ -30,6 +30,7 @@ class PredefinedKeyPositionIterator implements CardinalIterator
 
     public function rewind(): void
     {
+        $this->skipNext = false;
         reset($this->keyToPosition);
     }
 

--- a/tests/IteratorTest.php
+++ b/tests/IteratorTest.php
@@ -57,4 +57,22 @@ class IteratorTest extends TestCase
         }
         $this->assertEquals($repeated, $result);
     }
+
+    /**
+     * @dataProvider CardinalCollections\Tests\DataProviders\IteratorImplementationProvider::iteratorClassName
+     */
+    public function testIterationsCountAfterFirstElementRemoval($iteratorClass): void
+    {
+        $map = new Map([90 => 0, 501 => 0, 502 => 0], $iteratorClass);
+        self::assertCount(3, $map);
+        $map->remove(90);
+        self::assertCount(2, $map);
+        $i = 0;
+        $result = $map->map(function ($pid, $exitCode) use (&$i) {
+            $i++;
+            return [$pid, $exitCode];
+        });
+        self::assertCount(2, $result);
+        self::assertEquals(2, $i);
+    }
 }


### PR DESCRIPTION
PredefinedKeyPositionIterator wasn't resetting skipNext flag on rewind(), due to that we were repeating iteration on first element in set twice if we've removed first element before.